### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ I design systems that combine **smart contracts, AI agents, and real-world data*
 
 - 📌 **Live:** [ape.store](https://ape.store/)
 
-- 📌 **Repo:** [Smart Contract_v1](https://github.com/OnChainMee/evm-base-pumfun-smart-contract-v1
+- 📌 **Repo:** [Smart Contract_v1](https://github.com/OnChainMee/evm-base-pumfun-smart-contract-v1)
 
 ### **🔷 Yieldz Lending (Polygon)**
 <img align="right" width="350px" height="170px" src="https://github.com/user-attachments/assets/e16d639e-3c84-4e90-ac47-889373b477b0">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts a single URL with no runtime or behavioral impact.
> 
> **Overview**
> Fixes a broken Markdown link in `README.md` by adding the missing closing parenthesis for the `Smart Contract_v1` repository URL under **Ape Store - Base Token Launchpad**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7735f13b12b8ccac68a2bd5ac659289f62f0c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->